### PR TITLE
Mention timezone in digest post

### DIFF
--- a/datetimehelper.py
+++ b/datetimehelper.py
@@ -1,9 +1,15 @@
 from datetime import datetime, timedelta
 import pytz
+import sys
 from os import environ
 
 utc = pytz.utc
-localtz = pytz.timezone(environ["TIMEZONE"])
+
+try:
+    localtz = pytz.timezone(environ["TIMEZONE"])
+except pytz.UnknownTimeZoneError:
+    print("Unknown timezone specified, using UTC instead.", file=sys.stderr)
+    localtz = pytz.utc
 
 get_now = lambda :datetime.now(utc)
 

--- a/digest_manager.py
+++ b/digest_manager.py
@@ -5,7 +5,7 @@ import datetimehelper
 
 digest_header = """<details>
 <summary>
-<h2>Digest Summary: {time_end}</h2>
+<h2>Digest Summary: {time_end} (timezone: {tz})</h2>
 <p>... contains {all_changes} changes across {issues_changed} issues, since {time_start}</p>
 </summary>
 
@@ -140,7 +140,8 @@ class DigestManager:
                     all_changes=total_changes,
                     issues_changed=len(issues),
                     body='',
-                    additional_issues=''
+                    additional_issues='',
+                    tz=datetimehelper.localtz.zone
                 ))
     
     def send_data(self, issues: list[GitIssue]):
@@ -188,7 +189,8 @@ class DigestManager:
                     all_changes=total_changes,
                     issues_changed=len(issues),
                     body=''.join(content),
-                    additional_issues=additional_issues_str
+                    additional_issues=additional_issues_str,
+                    tz=datetimehelper.localtz.zone
                 ))
         
         run_mutations([r1, r2])


### PR DESCRIPTION
Fixes #25 

Improve clarity in the digest post as without timezone information, it can be misleading to users.

It's also possible for users to include incorrect timezone info, therefore, an additional check should be included and let the timezone fall back to UTC should the provided timezone be invalid.