### PR TITLE
Remove mentions from digest

### DIFF
--- a/git_structures.py
+++ b/git_structures.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from gql_queries import ReadComments
 import datetimehelper
-from stringhelper import format_to_quote
+from stringhelper import format_to_quote, replace_references
 
 issue_title_template = "# {title} [#{number}]({link})\n"
 
@@ -113,7 +113,7 @@ class GitComment(ModifiableItem):
     def __init__(self, graphqlResult: dict, time_range: tuple[datetime, datetime]):
         super().__init__(graphqlResult)
         self.source_link = graphqlResult["url"]
-        self.body = graphqlResult["body"]
+        self.body = replace_references(graphqlResult["body"])
         self.time_range = time_range
 
     def to_markdown(self) -> str:
@@ -130,7 +130,7 @@ class GitComment(ModifiableItem):
                 body=format_to_quote(self.body),
                 status=self.get_status_str(self.time_range)
             )
-    
+
     @property
     def is_deleted(self) -> bool:
         """
@@ -169,7 +169,7 @@ class GitIssue(ModifiableItem):
         self.time_range = timeRange
         self.title = graphqlResult["title"]
         self.id = graphqlResult["id"]
-        self.body = graphqlResult["body"]
+        self.body = replace_references(graphqlResult["body"])
         self.comments = []
         self.comments_query = ReadComments(self.id)
         

--- a/stringhelper.py
+++ b/stringhelper.py
@@ -13,6 +13,13 @@ escape_trans = str.maketrans({
         '\f': '\\f'
     })
 
+def replace_references(x: str) -> str:
+    """
+    replace_references replaces all @ sign in the given string with a placeholder ＠ which will
+    not trigger Github's markdown parser to reference the actual user.
+    """
+    return x.replace("@", "＠")
+
 def format_to_quote(x: str) -> str:
     """
     format_to_quote formats the string to a markdown quote.


### PR DESCRIPTION
Fixes #34 

Comments and Issue descriptions containing user mentions in Github will cause Github to trigger a user mention.

As users shouldn't be alerted by the digest, let's replace all @ signs in with ＠ which will prevent mentions from being accidentally triggered.